### PR TITLE
Fix density on Nougat

### DIFF
--- a/app/src/main/java/screen/dimmer/pixelfilter/FilterService.java
+++ b/app/src/main/java/screen/dimmer/pixelfilter/FilterService.java
@@ -106,6 +106,7 @@ public class FilterService extends Service implements SensorEventListener {
         draw.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
         draw.setFilterBitmap(false);
         draw.setAntiAlias(false);
+        draw.setTargetDensity(metrics.densityDpi);
         view.setBackground(draw);
 
         WindowManager.LayoutParams params = getLayoutParams();


### PR DESCRIPTION
Android 7.0+ allows the user to change the display density through the Settings menu.
Changing it to anything other the default would make the app draw the patterns incorrectly.
Set the BitmapDrawable density to the appropriate value to fix this.