### PR TITLE
Don't display the activity when opening it just to start the service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:label="@string/app_name" >
         <activity
             android:name=".MainActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:configChanges="touchscreen|keyboard|keyboardHidden|navigation|screenLayout|uiMode|orientation|screenSize|smallestScreenSize"
             android:label="@string/app_name" >
             <intent-filter>

--- a/app/src/main/java/screen/dimmer/pixelfilter/MainActivity.java
+++ b/app/src/main/java/screen/dimmer/pixelfilter/MainActivity.java
@@ -68,7 +68,7 @@ public class MainActivity extends Activity implements CompoundButton.OnCheckedCh
                 }
             }
         }
-
+        setTheme(android.R.style.Theme_DeviceDefault);
         setContentView(R.layout.activity_main);
 
         final Boolean[] patternSelection = new Boolean[1];


### PR DESCRIPTION
When starting the main activity to open the service it would momentarily flash on the screen.
To avoid this, start with a translucent theme and change it a regular theme only when the activity is actually going to stay open.